### PR TITLE
Not ignore dirs/files starts with '_'

### DIFF
--- a/app/src/main/java/com/loopeer/codereader/utils/FileCache.java
+++ b/app/src/main/java/com/loopeer/codereader/utils/FileCache.java
@@ -73,7 +73,7 @@ FileCache {
             directoryNode.isDirectory = true;
             directoryNode.pathNodes = new ArrayList<>();
             for (File childFile : file.listFiles()) {
-                if (childFile.getName().startsWith(".") || childFile.getName().startsWith("_")) continue;
+                if (childFile.getName().startsWith(".")) continue;
                 DirectoryNode childNode = getFileDirectory(childFile);
                 directoryNode.pathNodes.add(childNode);
             }


### PR DESCRIPTION
Python packages contain '__init__.py', ignoring files starts with '_'
will make it missing important files for Python projects.